### PR TITLE
Add PATH setup instructions for Slurm commands after install

### DIFF
--- a/intermediate/2026/slurm/HANDSONLAB.md
+++ b/intermediate/2026/slurm/HANDSONLAB.md
@@ -62,6 +62,25 @@ run rpmbuild" path entirely.
 the "does the slurm DB user exist?" check. On a fresh install it doesn't,
 so the playbook ignores the failure and creates it in the next task.
 
+### Put the Slurm commands on your PATH
+
+The install writes `/etc/profile.d/slurm.sh`, which prepends
+`/opt/slurm/current/bin` to `PATH`. But files in `/etc/profile.d/` are only
+sourced by **login** shells — and the root shell that ran `install_all.sh`
+was started *before* the install, so it never picked it up. Until you fix
+this, `sinfo`, `sacctmgr`, and friends are "command not found" (and
+`scripts/create_users_groups.sh` aborts at the Slurm step with
+"sacctmgr not found"). Do one of:
+
+```bash
+source /etc/profile.d/slurm.sh   # activate in the current shell, now
+# or
+exit; sudo -i                    # drop root and get a fresh login shell
+```
+
+Sourcing your `~/.bashrc` does **not** help — `.bashrc` doesn't read
+`/etc/profile.d/`; only the login-shell startup path does.
+
 ---
 
 ## 1. Verify the install

--- a/intermediate/2026/slurm/commands
+++ b/intermediate/2026/slurm/commands
@@ -33,6 +33,13 @@ cd ~/lci-scripts/intermediate/2026/slurm
 # install it doesn't, the playbook ignores the failure and creates it
 # in the next task.
 
+# Activate the Slurm commands on PATH. The install wrote
+# /etc/profile.d/slurm.sh (puts /opt/slurm/current/bin on PATH), but
+# profile.d is only sourced by *login* shells - the root shell that ran
+# install_all.sh predates it, so sinfo/sacctmgr/etc aren't on PATH yet.
+# Source it now (or log out and `sudo -i` again for a fresh login shell):
+source /etc/profile.d/slurm.sh
+
 # Tear down and re-run (cleans up everything install_all.sh installed):
 # ./uninstall_all.sh
 # ./install_all.sh XX

--- a/intermediate/2026/slurm/install_all.sh
+++ b/intermediate/2026/slurm/install_all.sh
@@ -130,6 +130,15 @@ echo
 echo "============================================================"
 echo ">>> Install complete for cluster ${CN}."
 echo "============================================================"
+echo
+echo "IMPORTANT - activate the Slurm commands on PATH:"
+echo "  The install wrote /etc/profile.d/slurm.sh (puts"
+echo "  /opt/slurm/current/bin on PATH), but profile.d is only sourced"
+echo "  by *login* shells - this root shell predates the install, so"
+echo "  sinfo/sacctmgr/etc are NOT on PATH yet. Do ONE of:"
+echo "    source /etc/profile.d/slurm.sh    # this shell, right now"
+echo "    exit; sudo -i                     # or get a fresh login shell"
+echo
 echo "Verify the scheduler:"
 echo "    sinfo"
 echo "    systemctl status slurmctld slurmdbd"


### PR DESCRIPTION
The install writes /etc/profile.d/slurm.sh to prepend /opt/slurm/current/bin to PATH, but profile.d is only sourced by login shells. The root shell running install_all.sh predates this, so sinfo/sacctmgr and other commands remain "not found". Add instructions in HANDSONLAB.md, commands, and the install script output to source the profile.d file or start a fresh login shell to activate the Slurm commands.