### PR TITLE
Clarify /opt/slurm 0755 fix in install_all.sh

### DIFF
--- a/intermediate/2026/slurm/install_all.sh
+++ b/intermediate/2026/slurm/install_all.sh
@@ -127,10 +127,13 @@ ansible-playbook -i hosts.ini -e "configless=${CONFIGLESS}" playbook.yml
 # Step 2b: Ensure /opt/slurm is traversable by all users
 # ============================================================
 # All users (bob, alice, ... created in the lab) must be able to traverse
-# into /opt/slurm/current/bin to run srun/sbatch/etc. The playbook now
-# creates /opt/slurm 0755 on both head and compute, so this is normally a
-# no-op - but we re-assert it here so the wrapper also self-heals a cluster
-# that was built before that fix (where /opt/slurm was 0750 on the head and
+# into /opt/slurm/current/bin to run srun/sbatch/etc. In practice only the
+# top-level /opt/slurm is the bottleneck: the Slurm build creates
+# /opt/slurm/current and .../bin already traversable (0755), so opening up
+# /opt/slurm alone is enough for everyone to reach the binaries. The
+# playbook now creates /opt/slurm 0755 on both head and compute, so this is
+# normally a no-op - but we re-assert it here so the wrapper also
+# self-heals a cluster built before that fix (where /opt/slurm was 0750 and
 # only slurm + the 'rocky' group could enter, giving everyone else
 # "Permission denied").
 echo


### PR DESCRIPTION
## Summary

Refines the Step 2b permission fix in `install_all.sh` that opens `/opt/slurm` to `0755` so all lab users can reach the Slurm binaries in `/opt/slurm/current/bin/`.

The Slurm build already creates `/opt/slurm/current` and `.../bin` traversable, so `chmod 0755 /opt/slurm` alone is sufficient — the top-level dir was the only bottleneck (verified on the head node and `lci-compute-33-1`). This keeps the fix to the single directory that always exists post-install, avoiding any dependency on subdirs under `set -e`.

## Changes Made

- Expanded the Step 2b comment to explain why only the top-level `/opt/slurm` needs opening
- Fix runs after Slurm install, on both head node (local `chmod`) and compute nodes (Ansible `file` module)

## Testing

- Behavior matches the manually-verified fix on the head node and `lci-compute-33-1` (users can run `srun`/`sbatch`/etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)