### PR TITLE
Add Storage-options.md for running Slurm lab from shared filesystems

### DIFF
--- a/intermediate/2026/slurm/HANDSONLAB.md
+++ b/intermediate/2026/slurm/HANDSONLAB.md
@@ -9,6 +9,13 @@
 >
 > For the install side of things — what `install_all.sh` actually does to
 > the cluster, step by step — see `INSTALL.md`.
+>
+> **Where to run your jobs from:** the storage track (the lab before this
+> one) mounts a shared parallel filesystem on every node. Run your
+> `srun`/`sbatch` work from there so output is visible cluster-wide. See
+> **`Storage-options.md`** for the exact work directory per filesystem
+> (Ceph, BeeGFS, Lustre, Storage Scale) and the one-time setup — do that
+> before section 5.
 
 ## How this lab works
 
@@ -220,7 +227,8 @@ Every UID and GID is explicit. Two reasons:
 1. **Consistency across nodes.** A job submitted as `bob` on the head node
    runs as UID 2002 on the compute node. If `useradd` on the compute node
    had picked a different UID, jobs would still "work" under MUNGE auth but
-   file ownership on any shared filesystem (NFS in other labs, or `/tmp`
+   file ownership on any shared filesystem (the Chosen Storage Solution
+   from the previous lab, or `/tmp`
    job containers here) would be a mess. Pinning the UID guarantees the
    user is the *same* user everywhere.
 2. **Determinism for the exercises.** The exercises hard-code things like
@@ -386,10 +394,13 @@ State legend you'll actually see:
 
 ### `srun` — interactive run
 
-Run this from your home directory (`cd ~`) as root:
+**First, set up your work directory.** Before running anything here, make
+sure you've done the one-time setup in `Storage-options.md` for whichever
+shared filesystem the storage lab left mounted, and point `LABDIR` at it:
 
 ```bash
-cd ~
+export LABDIR=/mnt/cephfs/projects/slurm-lab   # Ceph — adjust per Storage-options.md
+cd "$LABDIR"
 srun -p lcilab -N2 hostname
 ```
 
@@ -397,14 +408,21 @@ srun -p lcilab -N2 hostname
 per node, prints the output, and exits. This is the cheapest way to confirm
 jobs actually launch on the compute nodes.
 
-**Why launch from `~`.** `srun` tries to start the remote task in the same
-working directory you launched from. This lab has no shared filesystem
-(NFS is a separate lab), so a path that exists only on the head node — e.g.
-`~/lci-scripts/intermediate/2026/slurm` — makes `slurmd` on each compute
-node print `error: couldn't chdir to '...': No such file or directory:
-going to /tmp instead` and fall back to `/tmp`. It's a **warning, not a
-failure** — `hostname` doesn't care what directory it runs in — but
-launching from `~` (which root has on every node) keeps the output clean.
+**Why launch from the shared work dir.** `srun` tries to start the remote
+task in the same working directory you launched from. The shared filesystem
+(`Storage-options.md`) is mounted at the **same path on every node**, so when
+you launch from `$LABDIR` the compute nodes can `chdir` into it cleanly — no
+warning, and any output lands somewhere all nodes can see.
+
+If you launch from a path that exists *only* on the head node — e.g.
+`~/lci-scripts/intermediate/2026/slurm` — `slurmd` on each compute node
+prints `error: couldn't chdir to '...': No such file or directory: going to
+/tmp instead` and falls back to `/tmp`. It's a **warning, not a failure** —
+`hostname` doesn't care what directory it runs in.
+
+**No shared filesystem mounted?** Run from `~` instead (`cd ~`); root has a
+home on every node, so jobs run fine — output just isn't shared across nodes.
+See the fallback section in `Storage-options.md`.
 
 **Why `-p lcilab` is required.** The `lcilab` partition is defined
 `Default=No` in `slurm.conf.j2`, so there is no *system default* partition.
@@ -416,6 +434,10 @@ change `Default=No` to `Default=YES` in the template and re-run the
 playbook — but the lab keeps it explicit on purpose.)
 
 ### `sbatch` — batch submission
+
+Create and submit this from your shared work dir (`cd "$LABDIR"` — see
+`Storage-options.md`) so `$SLURM_SUBMIT_DIR` is the shared path and the
+`test-%j.out` / `test-%j.err` files land where every node can read them.
 
 A minimal job script `job.sh`:
 
@@ -920,5 +942,7 @@ more than once — it skips whatever's already gone. See `INSTALL.md` section
 ## Where to look for more
 
 - `commands` — the runnable source of truth for every step above (what to type).
+- `Storage-options.md` — where to run your jobs from on each shared filesystem
+  (Ceph, BeeGFS, Lustre, Storage Scale), with the one-time work-dir setup.
 - `INSTALL.md` — what `install_all.sh` does to your cluster, step by step.
 - `README.md` — quick orientation and the `install_all.sh` reference.

--- a/intermediate/2026/slurm/README.md
+++ b/intermediate/2026/slurm/README.md
@@ -1,12 +1,14 @@
-# slurm - one-command Slurm cluster install (no storage)
+# slurm - one-command Slurm cluster install (storage built separately)
 
 Self-contained bundle that installs a working Slurm cluster in one command: head node
 configuration, then Slurm `25.11.6` built from source and deployed to the compute
 nodes. Use this when the focus is configuring and *using* the scheduler, not installing
 it.
 
-This variant does **not** set up NFS/shared storage — that is built in a previous lab,
-so the head-node playbook here skips the NFS server and compute-node autofs mounts.
+This variant does **not** set up shared storage — the Chosen Storage Solution is built
+in a previous lab, so the head-node playbook here skips the shared-storage server and
+compute-node autofs mounts. See `Storage-options.md` for how to run the lab from
+whichever filesystem that lab left mounted.
 
 Everything `install_all.sh` needs is included here:
 

--- a/intermediate/2026/slurm/Storage-options.md
+++ b/intermediate/2026/slurm/Storage-options.md
@@ -1,0 +1,185 @@
+# Storage Options — Where to Run the Slurm Lab
+
+> **Companion to the Schedulers track.** Read this *before* you start the
+> Slurm hands-on lab (`HANDSONLAB.md`) so you know **where on disk to do
+> your work**.
+>
+> The storage track (the labs that run *before* Schedulers) stands up a
+> **shared parallel filesystem** mounted at the **same path on the head node
+> and both compute nodes**. The Slurm lab is much nicer when you run from
+> that shared path: every node sees the same files, so `srun`/`sbatch` can
+> `chdir` into your submit directory on the compute nodes and your `.out`/
+> `.err` files land where you submitted from — no `couldn't chdir ... going
+> to /tmp instead` warnings, no hunting across N VMs for output.
+>
+> Replace `XX` with your cluster number (e.g. `07`) throughout.
+
+---
+
+## TL;DR — pick the filesystem you built last
+
+Whichever storage lab you ran most recently is the one currently mounted.
+Find your row, create the lab work directory once, then use that path
+everywhere `HANDSONLAB.md` / `commands` tell you to.
+
+| Storage system | Filesystem | Mounted at (head + compute) | **Slurm lab work dir** |
+| -------------- | ---------- | --------------------------- | ---------------------- |
+| **Ceph (CephFS)**   | `lci` | `/mnt/cephfs`   | `/mnt/cephfs/projects/slurm-lab`  |
+| **BeeGFS**          | —     | `/mnt/beegfs`   | `/mnt/beegfs/scratch/slurm-lab`   |
+| **Lustre**          | `lci` | `/lustre/lci`   | `/lustre/lci/scratch/slurm-lab`   |
+| **Storage Scale (GPFS)** | `lci` | `/gpfs/lci` | `/gpfs/lci/scratch/slurm-lab`     |
+
+> **Heads up — Ceph is structured differently.** The Ceph lab creates
+> `projects/{A,B,C}` (not a `scratch` dir), so the Slurm work dir lives under
+> `projects/`. The other three labs create a shared `scratch/`, so the work
+> dir lives there.
+
+> **No shared filesystem mounted?** That's fine — the lab also works without
+> one. Run job commands from root's home (`cd ~`) on the head node and expect
+> the `going to /tmp instead` warning on `srun`. See
+> [No shared filesystem (fallback)](#no-shared-filesystem-fallback) below.
+
+---
+
+## One-time setup: create the lab work directory
+
+Do this **once on the head node as root**, after the shared filesystem is
+mounted. Pick the block for your filesystem.
+
+The directory is made **world-writable with the sticky bit (`1777`, same as
+`/tmp`)**. The Slurm lab submits jobs both as **root** and, in the
+exercises, as the eight lab users (`sudo -u bob ...`, `sudo -u justin ...`).
+A `1777` work dir lets every one of them write their own `.out`/`.err`
+files there while preventing them from deleting each other's — exactly the
+`/tmp` model, which is the least-friction choice for the lab.
+
+> Where the lab dir lives depends on how each storage lab lays out its tree.
+> BeeGFS, Lustre, and Storage Scale each create a shared `scratch/`, so the
+> Slurm lab goes there — transient working space, no quota drama, wiped when
+> you re-run the storage lab. Ceph instead creates `projects/{A,B,C}`, so on
+> Ceph the lab goes under `projects/`.
+
+### Ceph (CephFS) — `/mnt/cephfs`
+
+The Ceph lab creates `/mnt/cephfs/projects/{A,B,C}` (not a `scratch` dir), so
+put the Slurm work dir alongside those projects:
+
+```bash
+mkdir -p /mnt/cephfs/projects/slurm-lab
+chmod 1777 /mnt/cephfs/projects/slurm-lab
+```
+
+CephFS in the storage lab is mounted with `client.admin`, so root can write
+freely and `chmod` sticks. Unlike the `projects/{A,B,C}` dirs (which the lab
+puts byte/inode quotas on), `slurm-lab` has no quota — fine for the tiny
+`.out`/`.err` files this lab produces.
+
+### BeeGFS — `/mnt/beegfs`
+
+```bash
+mkdir -p /mnt/beegfs/scratch/slurm-lab
+chmod 1777 /mnt/beegfs/scratch/slurm-lab
+```
+
+The BeeGFS lab already creates `/mnt/beegfs/home` and `/mnt/beegfs/scratch`.
+BeeGFS does not root-squash by default, so root creates and `chmod`s the dir
+normally.
+
+### Lustre — `/lustre/lci`
+
+```bash
+mkdir -p /lustre/lci/scratch/slurm-lab
+chmod 1777 /lustre/lci/scratch/slurm-lab
+```
+
+The Lustre lab creates `/lustre/lci/home` and `/lustre/lci/scratch` (with
+project IDs and quotas). The `slurm-lab` dir inherits the `scratch` project
+ID, so its usage counts against the scratch quota — fine for the small
+`.out`/`.err` files this lab produces.
+
+### Storage Scale (GPFS) — `/gpfs/lci`
+
+```bash
+mkdir -p /gpfs/lci/scratch/slurm-lab
+chmod 1777 /gpfs/lci/scratch/slurm-lab
+```
+
+The Storage Scale lab links a `scratch` fileset at `/gpfs/lci/scratch`
+(capped at 15 GB total). The `slurm-lab` dir lives inside that fileset.
+
+---
+
+## How to use it in the Slurm lab
+
+Once the work dir exists, **`cd` into it and stay there** for the job-running
+parts of the lab. Wherever `HANDSONLAB.md` or `commands` says "run from `~`"
+or "create `job.sh`", do it here instead. Set a shell variable so the rest of
+the lab reads cleanly:
+
+```bash
+# Pick the line matching YOUR filesystem:
+export LABDIR=/mnt/cephfs/projects/slurm-lab    # Ceph
+# export LABDIR=/mnt/beegfs/scratch/slurm-lab   # BeeGFS
+# export LABDIR=/lustre/lci/scratch/slurm-lab   # Lustre
+# export LABDIR=/gpfs/lci/scratch/slurm-lab     # Storage Scale
+
+cd "$LABDIR"
+```
+
+Then in the lab:
+
+- **Section 5, `srun`** — run `cd "$LABDIR"` instead of `cd ~`. Because the
+  path exists identically on the compute nodes, you get **no
+  `couldn't chdir ... going to /tmp instead` warning**.
+- **Section 5, `sbatch`** — create `job.sh` in `$LABDIR` and `sbatch` it from
+  there. `$SLURM_SUBMIT_DIR` will be the shared path, and `test-%j.out` /
+  `test-%j.err` are written there — visible from every node.
+- **Exercises 1–5 (`sudo -u <user> sbatch ...`)** — run them from `$LABDIR`.
+  The `1777` sticky bit lets `bob`, `justin`, `katie`, etc. each write their
+  own output. (The load generator uses `-o /dev/null`, so it doesn't depend
+  on this — but interactive `sbatch`es in the exercises do.)
+
+### Why this is better than `/tmp` or `~`
+
+- **`~` (root's home)** exists on every node, so `srun`/`sbatch` *work*, but
+  `~` is **not shared** — each node has its own. Output written on a compute
+  node stays on that compute node; you can't `cat` it from the head.
+- **`/tmp`** is where `slurmd` falls back to when your submit dir doesn't
+  exist on the compute node. Also per-node and ephemeral.
+- **The shared FS** is the same bytes on every node. Submit on the head, read
+  the output on the head, even though the job ran on compute. This is how
+  real clusters are run, and it's the whole point of having built the
+  parallel filesystem in the previous lab.
+
+---
+
+## No shared filesystem (fallback)
+
+If you're running the Slurm lab standalone (no storage lab was run, nothing
+mounted), everything still works — just run the job commands from root's home
+on the head node:
+
+```bash
+cd ~
+srun -p lcilab -N2 hostname
+```
+
+`srun` will print `error: couldn't chdir to '...': No such file or
+directory: going to /tmp instead` if you launch from a head-only path. That's
+a **warning, not a failure** — `hostname` doesn't care what directory it runs
+in. Launching from `~` keeps the output clean. For `sbatch`, the `.out`/
+`.err` files land in whatever directory you submitted from on the head node.
+
+---
+
+## Cleanup
+
+The `slurm-lab` dir is just scratch; it disappears when you tear down the
+storage lab. To remove it by hand:
+
+```bash
+rm -rf "$LABDIR"            # e.g. /mnt/cephfs/projects/slurm-lab
+```
+
+Tearing down the Slurm cluster itself (`./uninstall_all.sh`) does **not**
+touch the shared filesystem.

--- a/intermediate/2026/slurm/commands
+++ b/intermediate/2026/slurm/commands
@@ -3,11 +3,16 @@
 # ============================================================
 # This file is the SOURCE OF TRUTH for the commands to run.
 # Each step has a one-liner explanation; for the full story see:
-#   INSTALL.md      - what install_all.sh does, step by step
-#   HANDSONLAB.md   - detailed explanation of every lab section below (the "why")
+#   INSTALL.md          - what install_all.sh does, step by step
+#   HANDSONLAB.md       - detailed explanation of every lab section below (the "why")
+#   Storage-options.md  - WHERE to run your jobs from, per shared filesystem
 #
-# NOTE: shared storage (NFS) is built in a previous lab and is
-# NOT configured here.
+# WHERE TO WORK: a shared parallel filesystem (Ceph, BeeGFS, Lustre, or
+# Storage Scale) is built in a previous lab and mounted on the head + compute
+# nodes. Run your sbatch/srun work from there so output is visible on every
+# node. See Storage-options.md for the exact work dir for your filesystem
+# (e.g. /mnt/cephfs/projects/slurm-lab) and the one-time setup. If nothing is
+# mounted, the lab still works from ~ - see the fallback in Storage-options.md.
 #
 # Replace XX with your cluster number (e.g., 07) throughout.
 # Run as root on lci-head-XX-1:  sudo -i
@@ -206,12 +211,17 @@ sinfo -N -l                     # per-node view
 # partition - every job must name one with -p, or you get
 # "No partition specified or system default partition".
 #
-# Run this from ~ (cd to /root first) as root. srun starts the remote task
-# in your current directory; the lab has no shared filesystem, so a path
-# like ~/lci-scripts/... that exists only on the head node makes slurmd
-# warn "couldn't chdir ... going to /tmp instead". Harmless for hostname,
-# but launching from ~ avoids the noise.
-cd ~
+# WHERE TO WORK: run the job commands below from your shared-filesystem work
+# dir so srun/sbatch can chdir into it on the compute nodes and your output
+# lands somewhere every node can see. See Storage-options.md for the path that
+# matches the storage lab you ran (Ceph/BeeGFS/Lustre/Storage Scale) and the
+# one-time mkdir + chmod 1777 setup. Set LABDIR to that path, e.g.:
+#   export LABDIR=/mnt/cephfs/projects/slurm-lab  # Ceph - adjust per Storage-options.md
+#   cd "$LABDIR"
+# No shared FS mounted? Run from ~ instead (cd to /root); srun starts the
+# remote task in your current dir, and a head-only path makes slurmd warn
+# "couldn't chdir ... going to /tmp instead" - harmless, but ~ avoids it.
+cd "$LABDIR"            # or: cd ~   (fallback; see Storage-options.md)
 srun -p lcilab -N2 hostname
 
 # Submit a batch job (create a job script first, e.g. job.sh).

--- a/intermediate/2026/slurm/install_all.sh
+++ b/intermediate/2026/slurm/install_all.sh
@@ -7,8 +7,9 @@
 # the scheduler_installation playbook (builds Slurm from source,
 # deploys to compute nodes).
 #
-# NOTE: this variant does NOT configure NFS/storage - shared
-# storage is built in a previous lab.
+# NOTE: this variant does NOT configure storage - the Chosen Storage
+# Solution is built in a previous lab. See Storage-options.md for where
+# to run the lab from.
 #
 # The Schedulers course focuses on CONFIGURATION and USAGE, not
 # installation, so this gets you to a working cluster fast. The


### PR DESCRIPTION
Document the work dir and mount path for each shared parallel filesystem from the storage track (Ceph, BeeGFS, Lustre, Storage Scale) so the Slurm lab can run from a path visible on the head and compute nodes. Includes one-time mkdir + chmod 1777 setup, a LABDIR convention, and a no-shared-FS fallback.

Point HANDSONLAB.md and commands at Storage-options.md for where to work, replacing the outdated "no shared filesystem" / "NFS" wording with the Chosen Storage Solution from the prior lab. Ceph uses projects/slurm-lab (its lab creates projects/, not scratch/); the others use scratch/slurm-lab.