### PR TITLE
Comment out DEPTH_OBLIVIOUS in introductory scheduler_installation co…

### DIFF
--- a/introductory/2026/scheduler_installation/Scheduler_installation_playbook/roles/slurm-source/files/slurm.conf
+++ b/introductory/2026/scheduler_installation/Scheduler_installation_playbook/roles/slurm-source/files/slurm.conf
@@ -58,7 +58,10 @@ ScronParameters=enable
 SelectType=select/cons_tres
 SelectTypeParameters=CR_Core_Memory,CR_CORE_DEFAULT_DIST_BLOCK
 PriorityType=priority/multifactor
-PriorityFlags=DEPTH_OBLIVIOUS
+# DEPTH_OBLIVIOUS collapses the hierarchical fairshare depth calculation and
+# changes the fairshare scores. The hands-on lab (Exercise 1/2) relies on
+# hierarchical fairshare, so keep this commented out.
+#PriorityFlags=DEPTH_OBLIVIOUS
 #PriorityFavorSmall=YES
 
 #PriorityDecayHalfLife=7-0

--- a/introductory/2026/scheduler_installation/Scheduler_installation_playbook/roles/slurm-source/templates/slurm.conf.j2
+++ b/introductory/2026/scheduler_installation/Scheduler_installation_playbook/roles/slurm-source/templates/slurm.conf.j2
@@ -58,7 +58,10 @@ ScronParameters=enable
 SelectType=select/cons_tres
 SelectTypeParameters=CR_Core_Memory,CR_CORE_DEFAULT_DIST_BLOCK
 PriorityType=priority/multifactor
-PriorityFlags=DEPTH_OBLIVIOUS
+# DEPTH_OBLIVIOUS collapses the hierarchical fairshare depth calculation and
+# changes the fairshare scores. The hands-on lab (Exercise 1/2) relies on
+# hierarchical fairshare, so keep this commented out.
+#PriorityFlags=DEPTH_OBLIVIOUS
 #PriorityFavorSmall=YES
 
 #PriorityDecayHalfLife=7-0


### PR DESCRIPTION
…nfig

The introductory scheduler_installation playbook still shipped an active PriorityFlags=DEPTH_OBLIVIOUS in both its files/slurm.conf and templates/slurm.conf.j2, so a fresh install re-rendered it active. That flag collapses the hierarchical fairshare depth calculation the hands-on lab (Exercise 1/2) depends on. Comment it out in both files, matching the intermediate copies fixed in 36af1e3. No active copy remains in the repo.